### PR TITLE
登録APIの機能を修正

### DIFF
--- a/internal/conversion/null/null.go
+++ b/internal/conversion/null/null.go
@@ -1,0 +1,37 @@
+package null
+
+import "database/sql"
+
+func NullFromPtrString(param *string) sql.NullString {
+	var res sql.NullString
+	if param != nil {
+		res.String = *param
+		res.Valid = true
+		return res
+	}
+	res.Valid = false
+	res.String = ""
+	return res
+}
+
+func NullFromPtrStringOpt(param *string) sql.NullString {
+	var res sql.NullString
+	res.Valid = true
+	if param != nil {
+		res.String = *param
+		return res
+	}
+	res.String = "shortest"
+	return res
+}
+
+func NullFromPtrInt(param *int64) sql.NullInt64 {
+	var res sql.NullInt64
+	res.Valid = true
+	if param != nil {
+		res.Int64 = *param
+		return res
+	}
+	res.Int64 = 0
+	return res
+}

--- a/internal/database/mysql/tigira.go
+++ b/internal/database/mysql/tigira.go
@@ -3,11 +3,13 @@ package mysql
 import (
 	"SolutionDev/internal/domain"
 	"context"
+	"database/sql"
 )
 
 type Tigira interface {
 	Create(ctx context.Context, req []*domain.GPSInfo) error
 	GetGoalId(ctx context.Context, req *domain.Goal) (*domain.Goal, error)
+	Update(ctx context.Context, req *domain.GPSInfo) error
 }
 
 type tigira struct{}
@@ -30,4 +32,18 @@ func (t *tigira) GetGoalId(ctx context.Context, req *domain.Goal) (*domain.Goal,
 		return nil, err
 	}
 	return goal, nil
+}
+
+func (t *tigira) Update(ctx context.Context, req *domain.GPSInfo) error {
+	// 検索条件に一致するレコードのdeletedカラムの値を1に更新
+	err := DBFromCtx(ctx).
+		Model(&domain.GPSInfo{}).
+		Where(req).
+		Update("deleted", sql.NullInt64{Int64: 1, Valid: true}).Error
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/domain/tigira.go
+++ b/internal/domain/tigira.go
@@ -1,9 +1,13 @@
 package domain
 
+import "database/sql"
+
 type GPSInfo struct {
-	Id  int     `gorm:"column:id"`
-	Lat float64 `gorm:"column:longitude"`
-	Lng float64 `gorm:"column:latitude"`
+	Id  int            `gorm:"column:id"`
+	Lat float64        `gorm:"column:longitude"`
+	Lng float64        `gorm:"column:latitude"`
+	Opt sql.NullString `gorm:"column:option"`
+	Dlt sql.NullInt64  `gorm:"column:deleted"`
 }
 
 type Goal struct {

--- a/internal/server/request/tigira.go
+++ b/internal/server/request/tigira.go
@@ -1,10 +1,9 @@
 package request
 
-import "SolutionDev/internal/domain"
-
-type GetGoal struct {
-	GoalName string `param:"goal_name" validate:"required"`
-}
+import (
+	"SolutionDev/internal/conversion/null"
+	"SolutionDev/internal/domain"
+)
 
 type GPSInfo struct {
 	Latitude  float64 `json:"latitude" validate:"required"`
@@ -13,27 +12,32 @@ type GPSInfo struct {
 
 type PostGPSInfo struct {
 	GoalName string    `param:"goal_name" validate:"required"`
+	Option   *string   `json:"option" validate:"omitempty"`
 	GPSInfos []GPSInfo `json:"" validate:"required,dive"`
 }
 
-func (param *GetGoal) ToGoal() *domain.Goal {
-	return &domain.Goal{
-		GoalName: param.GoalName,
+func ToGPSInfo(gps GPSInfo, id int, opt *string) *domain.GPSInfo {
+	return &domain.GPSInfo{
+		Id:  id,
+		Lat: gps.Latitude,
+		Lng: gps.Longitude,
+		Opt: null.NullFromPtrStringOpt(opt),
+		Dlt: null.NullFromPtrInt(nil),
 	}
 }
 
-func ToGPSInfo(GPS GPSInfo, id int) *domain.GPSInfo {
+func (param *PostGPSInfo) ToSearchGPSInfo(id int) *domain.GPSInfo {
 	return &domain.GPSInfo{
 		Id:  id,
-		Lat: GPS.Latitude,
-		Lng: GPS.Longitude,
+		Opt: null.NullFromPtrStringOpt(param.Option),
+		Dlt: null.NullFromPtrInt(nil),
 	}
 }
 
 func (param *PostGPSInfo) ToGPSInfos(id int) []*domain.GPSInfo {
 	var GPSinfos []*domain.GPSInfo
 	for _, p := range param.GPSInfos {
-		GPSinfos = append(GPSinfos, ToGPSInfo(p, id))
+		GPSinfos = append(GPSinfos, ToGPSInfo(p, id, param.Option))
 	}
 	return GPSinfos
 }

--- a/internal/server/tigira.go
+++ b/internal/server/tigira.go
@@ -30,6 +30,11 @@ func (s *tigira) Create(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, "Database error")
 	}
 
+	err = s.rdb.Tigira.Update(ctx, req.ToSearchGPSInfo(goalId.GoalId))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, "Database error")
+	}
+
 	err = s.rdb.Tigira.Create(ctx, req.ToGPSInfos(goalId.GoalId))
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, "Database error")


### PR DESCRIPTION
## 目的
新たな経路をスマホからデータベースに登録するためのAPIを作成

## リクエスト
 - パスパラメータ（ゴール名）
 
| 論理名 | 型 | 必須 |
| :---: | :---: | :---: |
| goal_name | string | ○ |

（URL例）
https://localhost:8080/api/tigira/ドンキ
※ パスパラメータなので、正確には論理名などはない

 - **[更新箇所 option追加]** ボディ（経路情報）

| 論理名 | 型 | 必須 | 備考 |
| :---: | :---: | :---: | :---: |
| GPSInfos | array | ○ | - |
| latitude | float | ○ | - |
| longitude | float | ○ | - |
| option | string | × | **新規追加** |

（ボディ例 - option箇所は無しでも可）
```js
{
    "option" : "underground",
    "GPSinfos" : [
        {
            "latitude": 123.45,
            "longitude": 123.45
        },
        {
            "latitude": 123.45,
            "longitude": 123.45
        },
        {
            "latitude": 123.45,
            "longitude": 123.45
        },
        {
            "latitude": 123.45,
            "longitude": 123.45
        }
    ]
}
```

## レスポンス
 - ステータスコード