### PR TITLE
経路取得APIを作成

### DIFF
--- a/internal/database/mysql/tigira.go
+++ b/internal/database/mysql/tigira.go
@@ -10,6 +10,7 @@ type Tigira interface {
 	Create(ctx context.Context, req []*domain.GPSInfo) error
 	GetGoalId(ctx context.Context, req *domain.Goal) (*domain.Goal, error)
 	Update(ctx context.Context, req *domain.GPSInfo) error
+	List(ctx context.Context, req *domain.GPSInfo) ([]*domain.GPSInfo, error)
 }
 
 type tigira struct{}
@@ -46,4 +47,15 @@ func (t *tigira) Update(ctx context.Context, req *domain.GPSInfo) error {
 	}
 
 	return nil
+}
+
+func (t *tigira) List(ctx context.Context, req *domain.GPSInfo) ([]*domain.GPSInfo, error) {
+	var res []*domain.GPSInfo
+	err := DBFromCtx(ctx).
+		Where(&req).
+		Find(&res).Error
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }

--- a/internal/router/group.go
+++ b/internal/router/group.go
@@ -14,5 +14,6 @@ func (r *router) group(g *echo.Group) {
 	tigira := g.Group("/tigira")
 	{
 		tigira.POST("/:goal_name", r.rdb.Tigira.Create)
+		tigira.GET("/:goal_name", r.rdb.Tigira.Get)
 	}
 }

--- a/internal/server/request/tigira.go
+++ b/internal/server/request/tigira.go
@@ -16,6 +16,11 @@ type PostGPSInfo struct {
 	GPSInfos []GPSInfo `json:"" validate:"required,dive"`
 }
 
+type GetGPSInfo struct {
+	GoalName string  `param:"goal_name" validate:"required"`
+	Option   *string `json:"option" validate:"omitempty"`
+}
+
 func ToGPSInfo(gps GPSInfo, id int, opt *string) *domain.GPSInfo {
 	return &domain.GPSInfo{
 		Id:  id,
@@ -45,5 +50,19 @@ func (param *PostGPSInfo) ToGPSInfos(id int) []*domain.GPSInfo {
 func (param *PostGPSInfo) ToGPSInfoGoalId() *domain.Goal {
 	return &domain.Goal{
 		GoalName: param.GoalName,
+	}
+}
+
+func (param *GetGPSInfo) ToGPSInfo() *domain.Goal {
+	return &domain.Goal{
+		GoalName: param.GoalName,
+	}
+}
+
+func (param *GetGPSInfo) ToGoal(id int, opt *string) *domain.GPSInfo {
+	return &domain.GPSInfo{
+		Id:  id,
+		Opt: null.NullFromPtrStringOpt(opt),
+		Dlt: null.NullFromPtrInt(nil),
 	}
 }

--- a/internal/server/response/tigira.go
+++ b/internal/server/response/tigira.go
@@ -1,0 +1,26 @@
+package response
+
+import (
+	"SolutionDev/internal/domain"
+)
+
+type Goal struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
+func ToGoals(products []*domain.GPSInfo) []*Goal {
+	var res []*Goal
+	for _, p := range products {
+		res = append(res, ToGoal(p))
+	}
+
+	return res
+}
+
+func ToGoal(goal *domain.GPSInfo) *Goal {
+	return &Goal{
+		Latitude:  goal.Lat,
+		Longitude: goal.Lng,
+	}
+}

--- a/internal/server/tigira.go
+++ b/internal/server/tigira.go
@@ -3,6 +3,7 @@ package server
 import (
 	"SolutionDev/internal/database/mysql"
 	"SolutionDev/internal/server/request"
+	"SolutionDev/internal/server/response"
 	"github.com/labstack/echo/v4"
 	"net/http"
 )
@@ -41,4 +42,26 @@ func (s *tigira) Create(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, "Success")
+}
+
+func (s *tigira) Get(c echo.Context) error {
+	var req request.GetGPSInfo
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, "bad request")
+	}
+	if err := c.Validate(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, "bad request")
+	}
+	ctx := c.Request().Context()
+
+	goalId, err := s.rdb.Tigira.GetGoalId(ctx, req.ToGPSInfo())
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, "Database error")
+	}
+
+	res, err := s.rdb.Tigira.List(ctx, req.ToGoal(goalId.GoalId, req.Option))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, "Database error")
+	}
+	return c.JSON(http.StatusOK, response.ToGoals(res))
 }


### PR DESCRIPTION
## 目的
経路を取得するためのAPI
 - オプションとして地下や人混みを避けるなどの指定ができるようにする

## リクエスト（パスパラメータ & ボディ）
 - パスパラメータ（ゴール名）
   - ※ パスパラメータなので、正確には論理名などはない

| 論理名 | 型 | 必須 |
| :---: | :---: | :---: |
| goal_name | string | ○ |


（URL例）
https://localhost:8080/api/tigira/ドンキ


 - ボディ（オプション指定、必須ではない）
   -  ※  オプション指定無い場合は、最短ルートを返す

| 論理名 | 型 | 必須 |
| :---: | :---: | :---: |
| option | string | × |


（ボディ例）
```js
{
    "option" : "underground"
}
```

## レスポンス
 - json & ステータスコード

(json例)
```js
[
    {
        "latitude": 123.45,
        "longitude": 123.45
    },
    {
        "latitude": 123.45,
        "longitude": 123.45
    },
    {
        "latitude": 123.45,
        "longitude": 123.45
    },
    {
        "latitude": 123.45,
        "longitude": 123.45
    }
]
```
